### PR TITLE
Redirect all traffic to ona.com

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,1 +1,1 @@
-/*    https://ona.com/:splat    301!
+/*    https://ona.com/:splat    302!

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,1 +1,1 @@
-/*    https://ona.com/:splat    302!
+/*    https://ona.com    302!

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,1 @@
+/*    https://ona.com/:splat    301!


### PR DESCRIPTION
Adds a Netlify `_redirects` file to temporary redirect all pages and sub-pages to https://ona.com while preserving the URL path.

## Changes
- Added `static/_redirects` with a 302 redirect rule for all routes